### PR TITLE
Update python

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -5,7 +5,7 @@ argcomplete~=1.10.0
 beautifulsoup4~=4.8.0
 chardet==3.*
 docx2txt~=0.8
-extract-msg<=0.29.* #Last with python2 support
+extract-msg<=0.29 #Last with python2 support Removed .* fornew pip
 pdfminer.six==20191110 #Last with python2 support
 python-pptx~=0.6.18
 six~=1.12.0


### PR DESCRIPTION
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in textract setup command: 'install_requires' must be a string or iterable of strings containing valid project/version requirement specifiers; .* suffix can only be used with `==` or `!=` operators
          extract-msg<=0.29.*
                     ~~~~~~~^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata. ╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.